### PR TITLE
Fix bad regex. 

### DIFF
--- a/tools/snapshot/index.js
+++ b/tools/snapshot/index.js
@@ -46,8 +46,6 @@ module.exports = (COMPLETE) => {
       require('./tasks/sync/public_keys'),
       //Sync: events from the crowdsale contract
       require('./tasks/sync/contract'),
-      //Misc: Sanitize Registrations
-      require('./tasks/misc/sanitize-registrations'),
       (state, next) => {
         if(config.only_produce_final_snapshot && !state.frozen) {
           console.log("only_produce_final_snapshot is set to true, skipping wallet calculations and snapshot export.")

--- a/tools/snapshot/lib/globals.js
+++ b/tools/snapshot/lib/globals.js
@@ -1,6 +1,6 @@
 const bn = require('bignumber.js')
 
-global.VERSION                            = "0.4.4"
+global.VERSION                            = "0.4.5"
 
 //Crowdsale Globals
 global.CS_ADDRESS_CROWDSALE               = "0xd0a6e6c54dbc68db5db3a091b171a77407ff7ccf"

--- a/tools/snapshot/utilities/misc.js
+++ b/tools/snapshot/utilities/misc.js
@@ -63,7 +63,7 @@ const convert_ethpk_to_eospk = ( pubkey ) => {
 }
 
 const sanitize_user_input = ( input ) => {
-  return input.replace(/[^a-z0-9]+/g, '')
+  return input.replace(/[^a-zA-Z0-9]+/g, '')
 }
 
 module.exports = {


### PR DESCRIPTION
0.4.4 butchered every key in the database (irrecoverably) ... Third time's a charm? 

- Replace bad regex
- Remove test with bad regex.

You must completely resync (run without --resume)